### PR TITLE
fix: sentinel errorの比較をerrors.Is()に統一

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,11 @@
-# PostgreSQL
-# DATABASE_URL=postgresql://review_gym:review_gym_dev@localhost:5432/review_gym?sslmode=disable  # Not yet implemented - using in-memory store
-# DB_PASSWORD=review_gym_dev  # Not yet implemented - using in-memory store
+# Storage mode: set STORE_TYPE=postgres to use PostgreSQL (default: memory)
+# STORE_TYPE=postgres
 
-# Redis
-# REDIS_URL=redis://localhost:6379  # Not yet implemented - using in-memory store
+# PostgreSQL (required when STORE_TYPE=postgres)
+# DATABASE_URL=postgresql://review_gym:review_gym_dev@localhost:5432/review_gym?sslmode=disable
+
+# Redis (optional, enables caching layer)
+# REDIS_URL=redis://localhost:6379
 
 # Server
 API_PORT=8080

--- a/backend/cmd/migrate/main.go
+++ b/backend/cmd/migrate/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -47,12 +48,12 @@ func main() {
 
 	switch *direction {
 	case "up":
-		if err := m.Up(); err != nil && err != migrate.ErrNoChange {
+		if err := m.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
 			log.Fatalf("migration up failed: %v", err)
 		}
 		fmt.Println("migrations applied successfully")
 	case "down":
-		if err := m.Down(); err != nil && err != migrate.ErrNoChange {
+		if err := m.Down(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
 			log.Fatalf("migration down failed: %v", err)
 		}
 		fmt.Println("migrations rolled back successfully")

--- a/backend/cmd/review-gym/main.go
+++ b/backend/cmd/review-gym/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -75,7 +76,7 @@ func main() {
 	}()
 
 	log.Printf("review-gym API server starting on :%s", port)
-	if srvErr := srv.ListenAndServe(); srvErr != nil && srvErr != http.ErrServerClosed {
+	if srvErr := srv.ListenAndServe(); srvErr != nil && !errors.Is(srvErr, http.ErrServerClosed) {
 		log.Fatalf("server failed: %v", srvErr)
 	}
 }


### PR DESCRIPTION
## Summary
- `cmd/review-gym/main.go`: `http.ErrServerClosed` の比較を `!=` から `errors.Is()` に変更
- `cmd/migrate/main.go`: `migrate.ErrNoChange` の比較を `!=` から `errors.Is()` に変更（2箇所）
- `.env.example`: PostgreSQL/Redisが実装済みであるため、「Not yet implemented」コメントを削除し、`STORE_TYPE` 設定を追記

## Test plan
- [x] `go build -trimpath ./...` パス
- [x] `go test -race -count=1 ./...` 全テストパス
- [x] `golangci-lint run ./...` 0 issues
- [x] `gofumpt -d .` 差分なし
- [x] pre-commit hooks (format, lint, test) 全パス